### PR TITLE
Don't make releases the latest

### DIFF
--- a/src/releases.ts
+++ b/src/releases.ts
@@ -168,6 +168,7 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
         body,
         draft: false,
         prerelease: false,
+        make_latest: false,
       });
 
       const release = {

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -168,7 +168,7 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
         body,
         draft: false,
         prerelease: false,
-        make_latest: false,
+        make_latest: "false",
       });
 
       const release = {


### PR DESCRIPTION
Our current Terraform updater process involves finding the latest release via the GH API and updating to it. This means we won't be able to try out this Action at the same time unless it avoids creating the latest release.

This flag defaults to `true` in both the library [1] and API[2], but we'll override it -- hardcoded for now unless we need to make it an option in the future.

[1] https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/main/docs/repos/createRelease.md
[2] https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28&versionId=free-pro-team%40latest&productId=rest#create-a-release