### PR TITLE
Update action to use Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,5 +159,5 @@ outputs:
     description: JSON object mapping all module names to their details including path, latest tag, and latest tag version
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
GitHub is deprecating Node 20 in advance of its end-of-life 2026-04. So, still plenty of time

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ for context.

Happy to let this one go and wait for upstream to update to Node 24.